### PR TITLE
Replace Xvfb with headless chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos/ruby-23-centos7
 
 ENV RUBY_VERSION="2.3.7" \
-    BUNDLER_VERSION="1.16.6" \
+    BUNDLER_VERSION="1.17.3" \
     OPENRESTY_VERSION=1.11.2.1 \
     LUAROCKS_VERSION=2.3.0
 
@@ -14,8 +14,7 @@ ENV PATH="./node_modules/.bin:$PATH:/usr/local/nginx/sbin/:/usr/local/luajit/bin
     TZ=:/etc/localtime \
     LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2/ \
     ORACLE_HOME=/opt/oracle/instantclient_12_2/ \
-    DB=$DB \
-    QMAKE=/usr/bin/qmake-qt5
+    DB=$DB
 
 RUN echo --color > ~/.rspec \
 # enables SCL collections, so that we can use bundler
@@ -39,12 +38,18 @@ RUN yum install -y git \
 
 
 # various system deps
-RUN yum install -y epel-release \
- && yum install -y mysql-devel \
-                   Xvfb \
+RUN echo $'\n\
+[google-chrome]\n\
+name=google-chrome\n\
+baseurl=http://dl.google.com/linux/chrome/rpm/stable/x86_64\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
+ > /etc/yum.repos.d/google-chrome.repo \
+  && yum install -y epel-release \
+  && yum install -y mysql-devel \
                    firefox \
-                   qt5-qtwebkit-devel \
-                   libicu \
+                   google-chrome-stable \
                    unzip \
                    ImageMagick \
                    ImageMagick-devel \
@@ -52,21 +57,26 @@ RUN yum install -y epel-release \
                    openssl-devel \
                    libaio \
                    dbus \
-# sphinx deps + installation
                    postgresql-libs \
                    unixODBC \
   && yum clean all -y \
   && curl http://sphinxsearch.com/files/sphinx-2.2.11-1.rhel7.x86_64.rpm > /tmp/sphinx-2.2.11-1.rhel7.x86_64.rpm \
-  && yum install -y /tmp/sphinx-2.2.11-1.rhel7.x86_64.rpm
+  && yum install -y /tmp/sphinx-2.2.11-1.rhel7.x86_64.rpm \
+  && wget -N https://chromedriver.storage.googleapis.com/$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE)/chromedriver_linux64.zip -P /tmp \
+  && unzip /tmp/chromedriver_linux64.zip -d /tmp \
+  && rm /tmp/chromedriver_linux64.zip \
+  && mv -f /tmp/chromedriver /usr/local/bin/chromedriver \
+  && chown root:root /usr/local/bin/chromedriver \
+  && chmod 0755 /usr/local/bin/chromedriver
+
+
 
 RUN source $ENV \
  && npm install yarn -g \
  && rm -rf ~/.npm ~/.config
 
-
 ADD https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz /tmp/geckodriver.tar.gz
 RUN tar -xzvf /tmp/geckodriver.tar.gz -C /usr/local/bin/ && rm -rf /tmp/geckodriver.tar.gz
-
 
 WORKDIR /opt/system/
 
@@ -91,26 +101,8 @@ VOLUME [ "/opt/system/tmp/cache/", \
          "/home/ruby/.luarocks" \
        ]
 
-#
-#ADD http://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz /tmp/openresty.tar.gz
-#ADD https://github.com/keplerproject/luarocks/archive/v${LUAROCKS_VERSION}.tar.gz /tmp/luarocks.tar.gz
-#
-#RUN tar xzf /tmp/openresty.tar.gz -C /tmp/ \
-# && cd /tmp/openresty-${OPENRESTY_VERSION} \
-# && ./configure --with-pcre --prefix=/usr/local \
-# && make -j`grep -c processor /proc/cpuinfo` && make install \
-# && ln -sf /usr/local/luajit/bin/luajit-* /usr/local/luajit/bin/luajit \
-# && ln -sf /usr/local/luajit/include/luajit-* /usr/local/luajit/include/lua5.1 \
-# && rm -r /tmp/openresty-${OPENRESTY_VERSION} \
-# && tar xzf /tmp/luarocks.tar.gz -C /tmp/ \
-# && cd /tmp/luarocks-${LUAROCKS_VERSION} \
-# && ./configure --prefix=/usr/local/luajit --with-lua=/usr/local/luajit \
-#    --with-lua-lib=/usr/local/lualib --lua-version=5.1 --lua-suffix=jit \
-# && make build && make install \
-# && rm -rf /tmp/luarocks-${LUAROCKS_VERSION}
-
 USER default
 
-ENTRYPOINT ["container-entrypoint", "/usr/bin/xvfb-run", "-s", "-screen 0 1280x1024x24"]
+ENTRYPOINT ["container-entrypoint"]
 
 CMD ["script/jenkins.sh"]


### PR DESCRIPTION
We do not need anymore xvfb by using a headless browser for javascript
See https://github.com/3scale/porta/pull/494

TODO:

- [x] ability to use probably use firefox and chrome at the same time
- [x] Remove qt installation