### PR TITLE
[fix] Dockerfile: Do not append dbus-uuidgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN mkdir -p  /opt/system/tmp/cache/ \
               /home/ruby/.luarocks \
  && groupadd --gid 1042 3scale-dev \
  && usermod -aG 1042 default \
- && dbus-uuidgen | sudo tee -a /etc/machine-id \
+ && dbus-uuidgen | sudo tee /etc/machine-id \
  && chown -R default /opt/system
 
 VOLUME [ "/opt/system/tmp/cache/", \


### PR DESCRIPTION
Fixes

```
process 614: D-Bus library appears to be incorrectly set up; failed to read machine uuid: UUID file '/etc/machine-id' should contain a hex string of length 32, not length 65, with no other text
```
