### PR TITLE
[wip] [npm] Update npm to latest instead of using yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
 
 
 RUN source $ENV \
- && npm install yarn -g \
+ && npm install npm@^6.9.0 -g \
  && rm -rf ~/.npm ~/.config
 
 ADD https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz /tmp/geckodriver.tar.gz


### PR DESCRIPTION
The previous builds were not a 100% consistent with our environment requirements. Thus sometimes we were introducing bugs because of the compilation of our components using yarn instead of npm and in some cases breaking the deploying process.