### PR TITLE
Fixed resource class for machine executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 jobs:
   docker-build:
-    resource_class: small
+    resource_class: medium
     machine: true
     steps:
       - checkout


### PR DESCRIPTION
`small` is not a supported resource class type for the `machine` executor  - https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux