### PR TITLE
Add dependency libatomic1 required by flow-bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
                    dbus \
                    postgresql-libs \
                    unixODBC \
+                   libatomic1 \
   && wget http://mirror.centos.org/centos/7/os/x86_64/Packages/urw-fonts-2.4-16.el7.noarch.rpm \
   && rpm -ivh --nodeps urw-fonts-2.4-16.el7.noarch.rpm \
   && rm urw-fonts-2.4-16.el7.noarch.rpm  \


### PR DESCRIPTION
⚠️ Moved to https://github.com/3scale/system-builder/pull/24

After upgrading `flow-bin` to the latest [1], we get this error in CircleCI:
```
$ flow && eslint --ext .js,.jsx app/javascript spec/javascripts
/opt/app-root/src/project/node_modules/flow-bin/flow-linux64-v0.152.0/flow: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

[1] https://github.com/3scale/porta/pull/2473