### PR TITLE
Switches to quay.io hosted base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/ruby-25-centos7
+FROM quay.io/centos7/ruby-25-centos7
 
 ENV BUNDLER_VERSION="1.17.3" \
     OPENRESTY_VERSION=1.11.2.1 \


### PR DESCRIPTION
This helps us avoid docker hub rate limiting