### PR TITLE
Fix bundle config created as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,9 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
   && rm /tmp/chromedriver_linux64.zip \
   && mv -f /tmp/chromedriver /usr/local/bin/chromedriver \
   && chown root:root /usr/local/bin/chromedriver \
-  && chmod 0755 /usr/local/bin/chromedriver \
-  && bundle config build.pg --with-pg-config=/usr/pgsql-10/bin/pg_config
+  && chmod 0755 /usr/local/bin/chromedriver
+
+ENV PATH="$PATH:/usr/pgsql-10/bin"
 
 RUN source $ENV \
  && npm install yarn -g \


### PR DESCRIPTION
We should never run `bundle` as root.

The command [recently added](https://github.com/3scale/system-builder/blob/c2c779458d537f74a6e09e3bcbb22b03f5646cc6/Dockerfile#L81) (#28) to set the `build.pg` bundle config caused the bundle config file to be created and owned by the root user. This will result in fails in CI such as https://app.circleci.com/pipelines/github/3scale/porta/17242/workflows/64774e87-388d-4de4-aad7-bb282b4e57b5/jobs/212235.

The alternatives to fix include:
1. `chown` the bundle config file to user `default` after created by `root`
2. Run the command that sets the config _after_ the user is changed to `default`
3. Put `pg_config` in the `PATH` so building the Ruby gem `pg` does not fail in spite of the lack of a bundle config pointing to the binary