### PR TITLE
Use default postgres like in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,7 @@ RUN yum install -y git \
 RUN echo --color > ~/.rspec \
 # enables SCL collections, so that we can use bundler
  && source $ENV \
- && gem install bundler --version ${BUNDLER_VERSION} --no-doc \
- && bundle config build.pg --with-pg-config=/usr/pgsql-13/bin/pg_config
+ && gem install bundler --version ${BUNDLER_VERSION} --no-doc
 
 # various system deps
 RUN echo $'\n\
@@ -48,9 +47,7 @@ gpgcheck=1\n\
 gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
  > /etc/yum.repos.d/google-chrome.repo \
   && yum-config-manager  --setopt=skip_missing_names_on_install=False --save \
-  && rpm -Uvh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   && yum update -y \
-  && yum remove -y postgresql \
   && yum install -y epel-release \
   && yum install -y mysql-devel \
                    firefox \
@@ -62,7 +59,6 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
                    openssl-devel \
                    libaio \
                    dbus \
-                   postgresql13 postgresql13-devel postgresql13-libs \
                    unixODBC \
                    libatomic \
                    liberation-sans-fonts \
@@ -80,8 +76,6 @@ gpgkey=https://dl-ssl.google.com/linux/linux_signing_key.pub' \
   && mv -f /tmp/chromedriver /usr/local/bin/chromedriver \
   && chown root:root /usr/local/bin/chromedriver \
   && chmod 0755 /usr/local/bin/chromedriver
-
-ENV PATH="$PATH:/usr/pgsql-13/bin"
 
 RUN source $ENV \
  && npm install yarn -g \


### PR DESCRIPTION
In prod we use standard postgres library that comes with RHEL7. Do the same here. If we upgrade prod image, we will update this also there.

Once this is approved, I'll backport it to `master` and `ruby27` without reviews.