### PR TITLE
Add mirrors for CentOS 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ENV PATH="./node_modules/.bin:$PATH" \
 
 USER root
 
-RUN dnf -y module enable ruby:2.7 nodejs:16 mysql:8.0 \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+    && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+    && dnf -y module enable ruby:2.7 nodejs:16 mysql:8.0 \
     && dnf install -y --setopt=skip_missing_names_on_install=False,tsflags=nodocs \
         ruby-devel rubygem-rdoc rubygem-irb \
         nodejs \


### PR DESCRIPTION
Add mirrors for repos for CentOS 8

https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

> After May 31, 2024, CentOS Stream 8 will be archived and no further updates will be provided.
> The packages will be archived on vault.centos.org after May 31, 2024.