### PR TITLE
Upgrade bundler to version 2.3.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream9
 
-ENV BUNDLER_VERSION="2.2.25"
+ENV BUNDLER_VERSION="2.3.27"
 
 ARG DB=mysql
 


### PR DESCRIPTION
Because this is the version we have in the [`Gemfile.lock`](https://github.com/3scale/porta/blob/dc978ade606567eae1f62db3b47eae6e670e63f4/Gemfile.lock#L1138)