### PR TITLE
Install libyaml-devel package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN dnf -y module enable ruby:3.1 nodejs:18 \
         ruby-devel rubygem-irb \
         nodejs \
         sudo which file shared-mime-info unzip jq git \
-        postgresql libpq-devel mysql-devel zlib-devel gd-devel libxml2-devel libxslt-devel \
+        postgresql libpq-devel mysql-devel zlib-devel gd-devel libxml2-devel libxslt-devel libyaml-devel \
         make automake gcc gcc-c++ \
         # needed to log memory usage in CI \
         procps-ng \


### PR DESCRIPTION
Add `libyaml-devel` 

This was needed for Rails 7.1 builds, without it `bundle install` fails with the following error log:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/opt/ci/workdir/vendor/bundle/ruby/3.1.0/gems/psych-5.2.6/ext/psych
/usr/bin/ruby -I /usr/share/rubygems extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib64
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/bin/$(RUBY_BASE_NAME)
        --with-libyaml-source-dir
        --without-libyaml-source-dir
        --with-yaml-0.1-dir
        --without-yaml-0.1-dir
        --with-yaml-0.1-include
        --without-yaml-0.1-include=${yaml-0.1-dir}/include
        --with-yaml-0.1-lib
        --without-yaml-0.1-lib=${yaml-0.1-dir}/lib64
        --with-yaml-0.1-config
        --without-yaml-0.1-config
        --with-pkg-config
        --without-pkg-config
        --with-libyaml-dir
        --without-libyaml-dir
        --with-libyaml-include
        --without-libyaml-include=${libyaml-dir}/include
        --with-libyaml-lib
        --without-libyaml-lib=${libyaml-dir}/lib64

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

/opt/ci/workdir/vendor/bundle/ruby/3.1.0/extensions/x86_64-linux/3.1.0/psych-5.2.6/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in
/opt/ci/workdir/vendor/bundle/ruby/3.1.0/gems/psych-5.2.6 for inspection.
Results logged to
/opt/ci/workdir/vendor/bundle/ruby/3.1.0/extensions/x86_64-linux/3.1.0/psych-5.2.6/gem_make.out

  /usr/share/rubygems/rubygems/ext/builder.rb:102:in `run'
  /usr/share/rubygems/rubygems/ext/ext_conf_builder.rb:28:in `build'
  /usr/share/rubygems/rubygems/ext/builder.rb:171:in `build_extension'
  /usr/share/rubygems/rubygems/ext/builder.rb:205:in `block in build_extensions'
  /usr/share/rubygems/rubygems/ext/builder.rb:202:in `each'
  /usr/share/rubygems/rubygems/ext/builder.rb:202:in `build_extensions'
  /usr/share/rubygems/rubygems/installer.rb:843:in `build_extensions'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/rubygems_gem_installer.rb:72:in
`build_extensions'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/rubygems_gem_installer.rb:28:in
`install'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/source/rubygems.rb:207:in
`install'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/installer/gem_installer.rb:54:in
`install'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/installer/gem_installer.rb:16:in
`install_from_spec'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/installer/parallel_installer.rb:186:in
`do_install'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/installer/parallel_installer.rb:177:in
`block in worker_pool'
  /usr/share/gems/gems/bundler-2.3.27/lib/bundler/worker.rb:62:in `apply_func'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/worker.rb:57:in `block in
process_queue'
  /usr/share/gems/gems/bundler-2.3.27/lib/bundler/worker.rb:54:in `loop'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/worker.rb:54:in
`process_queue'
/usr/share/gems/gems/bundler-2.3.27/lib/bundler/worker.rb:91:in `block (2
levels) in create_threads'

An error occurred while installing psych (5.2.6), and Bundler cannot
continue.
```